### PR TITLE
snap.rb: support non-HEAD builds

### DIFF
--- a/Formula/snap.rb
+++ b/Formula/snap.rb
@@ -1,7 +1,16 @@
 class Snap < Formula
   desc "Tool to interact with snaps"
   homepage "https://snapcraft.io/"
-  head "https://github.com/snapcore/snapd.git"
+
+  stable do
+    version "2.36"
+    url "https://github.com/snapcore/snapd/releases/download/#{version}/snapd_#{version}.vendor.tar.xz"
+    sha256 "65a54a4e21419394859063e926a012f07c04a9bfb1146a28a3f48c9221331d86"
+  end
+
+  head do
+    url "https://github.com/snapcore/snapd.git"
+  end
 
   depends_on "go" => :build
   depends_on "squashfs"
@@ -12,9 +21,17 @@ class Snap < Formula
     (buildpath/"src/github.com/snapcore/snapd").install buildpath.children
 
     cd "src/github.com/snapcore/snapd" do
-      system "./get-deps.sh"
       system "go", "get", "golang.org/x/sys/unix"
-      system "./mkversion.sh"
+
+      if version.head?
+        system "./get-deps.sh"
+        system "./mkversion.sh"
+      elsif revision > 0
+        system "./mkversion.sh", "#{version}-#{revision}"
+      else
+        system "./mkversion.sh", "#{version}"
+      end
+
       system "go", "build", "-o", bin/"snap", "./cmd/snap"
 
       # Build bash completion


### PR DESCRIPTION
With 2.36 released, you can now do a non-HEAD build.