### PR TITLE
Added xdelta dependency for pushing snap package.

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -12,6 +12,7 @@ class Snapcraft < Formula
   depends_on "lxc"
   depends_on "squashfs"
   depends_on "python"
+  depends_on "xdelta"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz"


### PR DESCRIPTION
When I invoke `snapcraft push foo.snap`, I got the following error.

```
~/D/g/r/snap.ruby (master) > snapcraft push ruby_2.4.5_amd64.snap 
Pushing ruby_2.4.5_amd64.snap
Preparing to push '...'
Found cached source snap ...
A tool snapcraft depends on could not be found: 'xdelta3'.
Ensure the tool is installed and available, and try again.
Sorry, an error occurred in Snapcraft.
```

I added xdelta package via homebrew.